### PR TITLE
bugfix: Correctly import 'uuid' package

### DIFF
--- a/web3x/src/utils/encryption.ts
+++ b/web3x/src/utils/encryption.ts
@@ -18,7 +18,7 @@
 import aes from 'browserify-aes';
 import randomBytes from 'randombytes';
 import { isString } from 'util';
-import uuid from 'uuid';
+import * as uuid from 'uuid';
 import { pbkdf2, scrypt, sha3 } from '.';
 import { Address } from '../address';
 


### PR DESCRIPTION
This PR fixes the following typescript error
```
Attempted import error: 'uuid' does not contain a default export (imported as 'uuid').
```